### PR TITLE
Add yara rules from Kaspersky's Equation Group findings

### DIFF
--- a/rules/doublefantasy_config.yar
+++ b/rules/doublefantasy_config.yar
@@ -1,0 +1,22 @@
+rule apt_equation_doublefantasy_genericresource {
+ 
+meta:
+ 
+    copyright = "Kaspersky Lab"
+    description = "Rule to detect DoubleFantasy encoded config"
+    version = "1.0"
+    last_modified = "2015-02-16"
+    reference = "https://securelist.com/blog/"
+ 
+strings:
+ 
+    $mz="MZ"
+    $a1={06 00 42 00 49 00 4E 00 52 00 45 00 53 00}
+    $a2="yyyyyyyyyyyyyyyy"
+    $a3="002"
+ 
+ 
+condition:
+ 
+(($mz at 0) and all of ($a*))  and filesize < 500000
+}

--- a/rules/equation_cryptotable.yar
+++ b/rules/equation_cryptotable.yar
@@ -1,0 +1,19 @@
+rule apt_equation_cryptotable {
+ 
+meta:
+ 
+    copyright = "Kaspersky Lab"
+    description = "Rule to detect the crypto library used in Equation group malware"
+    version = "1.0"
+    last_modified = "2015-02-16"
+    reference = "https://securelist.com/blog/"
+ 
+strings:
+ 
+ 
+    $a={37 DF E8 B6 C7 9C 0B AE 91 EF F0 3B 90 C6 80 85 5D 19 4B 45 44 12 3C E2 0D 5C 1C 7B C4 FF D6 05 17 14 4F 03 74 1E 41 DA 8F 7D DE 7E 99 F1 35 AC B8 46 93 CE 23 82 07 EB 2B D4 72 71 40 F3 B0 F7 78 D7 4C D1 55 1A 39 83 18 FA E1 9A 56 B1 96 AB A6 30 C5 5F BE 0C 50 C1}
+ 
+condition:
+ 
+    $a
+}

--- a/rules/equation_exploitlib.yar
+++ b/rules/equation_exploitlib.yar
@@ -1,0 +1,25 @@
+rule apt_equation_exploitlib_mutexes {
+ 
+meta:
+ 
+    copyright = "Kaspersky Lab"
+    description = "Rule to detect Equation group's Exploitation library"
+    version = "1.0"
+    last_modified = "2015-02-16"
+    reference = "https://securelist.com/blog/"
+ 
+ 
+strings:
+ 
+    $mz="MZ"
+ 
+    $a1="prkMtx" wide
+    $a2="cnFormSyncExFBC" wide
+    $a3="cnFormVoidFBC" wide
+    $a4="cnFormSyncExFBC" 
+    $a5="cnFormVoidFBC"
+ 
+condition:
+ 
+(($mz at 0) and any of ($a*))
+}

--- a/rules/equation_runtimeclasses.yar
+++ b/rules/equation_runtimeclasses.yar
@@ -1,0 +1,23 @@
+rule apt_equation_equationlaser_runtimeclasses {
+ 
+meta:
+ 
+    copyright = "Kaspersky Lab"
+    description = "Rule to detect the EquationLaser malware"
+    version = "1.0"
+    last_modified = "2015-02-16"
+    reference = "https://securelist.com/blog/"
+ 
+strings:
+ 
+    $a1="?a73957838_2@@YAXXZ"
+    $a2="?a84884@@YAXXZ"
+    $a3="?b823838_9839@@YAXXZ"
+    $a4="?e747383_94@@YAXXZ"
+    $a5="?e83834@@YAXXZ"
+    $a6="?e929348_827@@YAXXZ"
+ 
+condition:
+ 
+    any of them
+}

--- a/rules/signatures.yar
+++ b/rules/signatures.yar
@@ -1,2 +1,6 @@
 include "rcs.yar"
 include "finfisher.yar"
+include "equation_cryptotable.yar"
+include "equation_exploitlib.yar"
+include "equation_runtimeclasses.yar"
+include "doublefantasy_config.yar"


### PR DESCRIPTION
Kaspersky Labs [published yara rules](https://securelist.com/blog/research/68750/equation-the-death-star-of-malware-galaxy/) for identifying infections from Equation group, the state sponsored attackers that apparently have more advanced capabilities than Stuxnet. These yara rules are directly from Kaspersky, and while their AV catches these infections, it might be plausible that someone looking for a tool to identify them would seek out a tool specifically for them.

It might also be worth crediting Kaspersky somewhere for them. I'm not even sure about their copyright or license, but I can only assume they published them to be used.
